### PR TITLE
Hotfix: replace all ">" and "<" in username

### DIFF
--- a/src/commands/gsmarena.js
+++ b/src/commands/gsmarena.js
@@ -199,7 +199,7 @@ module.exports = (bot) => {
     let userName = String(ctx.from.first_name);
 
     if(userName.includes("<") && userName.includes(">")) {
-      userName = userName.replace("<", "").replace(">", "");
+      userName = userName.replaceAll("<", "").replaceAll(">", "");
     }
 
     const phone = ctx.message.text.split(" ").slice(1).join(" ");


### PR DESCRIPTION
This will replace all instances of ">" and "<" in the user's name. Just using `.replace` will replace only one instance in the string.

Fixes #36 