### PR TITLE
Potential fix for code scanning alert no. 24: Inefficient regular expression

### DIFF
--- a/telegram/commands/help.ts
+++ b/telegram/commands/help.ts
@@ -30,7 +30,7 @@ function parseCommandsFromString(text: string): string[] {
   const commands: string[] = [];
 
   for (const line of lines) {
-    const match = line.match(/^-\s*\/([^\s:]+(?:\s*\|\s*\/[^\s:]+)*)[^:]*:\s*(.+)/);
+    const match = line.match(/^-\s*\/([^\s:|/]+(?:\s*\|\s*\/[^\s:|/]+)*)[^:]*:\s*(.+)/);
     if (match) {
       const [, cmdList, description] = match;
       const mainCmd = cmdList.split('|')[0].trim();


### PR DESCRIPTION
Potential fix for [https://github.com/abocn/TelegramBot/security/code-scanning/24](https://github.com/abocn/TelegramBot/security/code-scanning/24)

To fix the inefficient regular expression, we need to remove the ambiguity in the repeated group. The issue is that `[^\s:]+` can match any character except whitespace and colon, but the repeated group also matches similar patterns, leading to multiple ways to match the same string. The best way to fix this is to ensure that the repeated group does not overlap with the initial match. We can do this by making the repeated group match only characters that are not the separator (`|`) or `/`, or by using a more precise pattern for command alternatives.

A safe and efficient fix is to replace `[^\s:]+` with a pattern that matches command names more precisely, and in the repeated group, ensure that the alternatives are separated unambiguously. For example, we can use `([^\s:|/]+)` for command names, and in the repeated group, match `\s*\|\s*\/([^\s:|/]+)`.

Edit only the regular expression in the `parseCommandsFromString` function in telegram/commands/help.ts, line 33.

No new imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
